### PR TITLE
Add GitHub actions to compile and release binaries

### DIFF
--- a/.github/workflows/Tagged.yml
+++ b/.github/workflows/Tagged.yml
@@ -1,0 +1,48 @@
+name: Tagged build
+
+on:
+  push:
+    tags:
+      - 'r*.*.*'
+    paths-ignore:
+      - '.github/workflows/Untagged.yaml'
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  Win64:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get current date
+      run: echo "CurrentDate=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
+
+    - name: Get tag
+      run: echo "CommitTag=$(git describe --tags --abbrev=0 --match *.*.*)" >> $env:GITHUB_ENV
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Release folder
+      run: mkdir "Release"
+
+    - name: Compress artifacts
+      uses: vimtor/action-zip@v1.1
+      with:
+        files: 'build/bin/Release/'
+        dest: "Release/${{env.CurrentDate}}_MPEG-H_decoder_software_${{env.CommitTag}}.zip"
+
+    - name: GitHub Release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{secrets.GITHUB_TOKEN}}"
+        automatic_release_tag: "${{env.CommitTag}}"
+        prerelease: false
+        title: "[${{env.CurrentDate}}] MPEG-H decoder software ${{env.CommitTag}}"
+        files: "Release/*"

--- a/.github/workflows/Untagged.yml
+++ b/.github/workflows/Untagged.yml
@@ -1,0 +1,55 @@
+name: Untagged build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags-ignore:
+      - 'r*.*.*'
+    paths-ignore:
+      - '.github/workflows/Tagged.yaml'
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  Win64:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+
+    - name: Get current date
+      run: echo "CurrentDate=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
+
+    - name: Get commit hash and count
+      run: |
+        echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
+        echo "CommitCount=$(git rev-list --count main)" >> $env:GITHUB_ENV
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Release folder
+      run: mkdir "Release"
+
+    - name: Compress artifacts
+      uses: vimtor/action-zip@v1.1
+      with:
+        files: 'build/bin/Release/'
+        dest: "Release/${{env.CurrentDate}}_MPEG-H_decoder_software_${{env.CommitCount}}@${{env.CommitHashShort}}.zip"
+
+    - name: GitHub Release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{secrets.GITHUB_TOKEN}}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "[${{env.CurrentDate}}] MPEG-H decoder software ${{env.CommitCount}}@${{env.CommitHashShort}}"
+        files: "Release/*"


### PR DESCRIPTION
These GitHub actions workflows will compile and release Windows 64-bit executables (MPEG-H decoder and MPEG-H UI manager). 
- It will use <CommitNumber>@<CommitHashShort> for every commit and publish it as pre-release
- And for every manual tag that follows the current scheme (r#.#.#), it will publish binaries as a full/stable release.

Example: https://github.com/ThreeDeeJay/mpeghdec/releases